### PR TITLE
Remove new line in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![GoDoc](https://godoc.org/knative.dev/sample-controller?status.svg)](https://godoc.org/knative.dev/sample-controller)
 [![Go Report Card](https://goreportcard.com/badge/knative/sample-controller)](https://goreportcard.com/report/knative/sample-controller)
 
-Knative `sample-controller` defines a few simple resources that are validated by
-webhook and managed by a controller to demonstrate the canonical style in which
+Knative `sample-controller` defines a few simple resources that are validated by webhook and managed by a controller to demonstrate the canonical style in which
 Knative writes controllers.
 
 To learn more about Knative, please visit our


### PR DESCRIPTION
## What

・ Remove new line in the line which ends with "by"

## Why

・In some apps such like Github mobile, the new line will not be interpreted.

![29EFE5CE-C5EE-4435-9913-B392C7DF4C24](https://user-images.githubusercontent.com/23056537/69095672-ad7e3600-0a07-11ea-9d10-369edf2f29c2.jpeg)
